### PR TITLE
Add Victron Modbus TCP support and configuration options

### DIFF
--- a/include/yasolr.h
+++ b/include/yasolr.h
@@ -149,3 +149,9 @@ extern Mycila::RouterOutput* output1;
 extern Mycila::RouterOutput* output2;
 extern void yasolr_divert();
 extern void yasolr_init_router();
+
+// MODBUS TCP
+#include <ModbusClientTCP.h>  
+extern void yasolr_init_modbus(); 
+extern ModbusClientTCP* MB;
+extern float modbus_frequency;

--- a/include/yasolr_macros.h
+++ b/include/yasolr_macros.h
@@ -280,3 +280,8 @@
 #ifndef YASOLR_PZEM_TX_PIN
   #define YASOLR_PZEM_TX_PIN -1
 #endif
+
+//Modbus TCP configuration keys
+#define KEY_ENABLE_MODBUS                  "modbus_enable"
+#define KEY_MODBUS_SERVER                  "modbus_server"
+#define KEY_MODBUS_PORT                    "modbus_port"

--- a/include/yasolr_macros.h
+++ b/include/yasolr_macros.h
@@ -282,6 +282,6 @@
 #endif
 
 //Modbus TCP configuration keys
-#define KEY_ENABLE_MODBUS                  "modbus_enable"
-#define KEY_MODBUS_SERVER                  "modbus_server"
-#define KEY_MODBUS_PORT                    "modbus_port"
+#define KEY_ENABLE_VICTRON_MB                  "vic_mb_enable"
+#define KEY_VICTRON_MB_SERVER                  "vic_mb_server"
+#define KEY_VICTRON_MB_PORT                    "vic_mb_port"

--- a/platformio.ini
+++ b/platformio.ini
@@ -996,7 +996,7 @@ build_unflags =
 
 
 ; https://ota.apper-solaire.org
-[ESP32_D1_APPER]
+[esp32-d1-apper]
 build_flags =
   -D YASOLR_I2C_SCL_PIN=-1
   -D YASOLR_I2C_SDA_PIN=-1
@@ -1021,9 +1021,9 @@ build_flags =
   -D YASOLR_ZCD_PIN=19
 
 
-[env:oss-ESP32_D1_APPER]
+[env:oss-esp32-d1-apper]
 board = wemos_d1_uno32
-custom_safeboot_url = https://github.com/mathieucarbou/MycilaSafeBoot/releases/download/v2.0.1/safeboot-wemos_d1_uno32.bin
+custom_safeboot_url = https://github.com/mathieucarbou/MycilaSafeBoot/releases/download/v2.1.1/safeboot-wemos_d1_uno32.bin
 lib_deps =
   ${env.lib_deps}
   ${oss.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,8 +10,7 @@
 
 [platformio]
 name = YaSolR
-;default_envs = pro-esp32, pro-esp32s3, pro-lilygo_eth_lite_s3, pro-wt32_eth01
-default_envs = oss-ESP32_D1_APPER
+default_envs = pro-esp32, pro-esp32s3, pro-lilygo_eth_lite_s3, pro-wt32_eth01
 
 [env]
 build_type = release
@@ -996,7 +995,7 @@ build_unflags =
 
 
 
-;============ PKO ================================
+; https://ota.apper-solaire.org
 [ESP32_D1_APPER]
 build_flags =
   -D YASOLR_I2C_SCL_PIN=-1
@@ -1022,10 +1021,9 @@ build_flags =
   -D YASOLR_ZCD_PIN=19
 
 
-
 [env:oss-ESP32_D1_APPER]
 board = wemos_d1_uno32
-custom_safeboot_url = https://github.com/mathieucarbou/MycilaSafeBoot/releases/download/v1.0.6/safeboot-esp32dev.bin
+custom_safeboot_url = https://github.com/mathieucarbou/MycilaSafeBoot/releases/download/v2.0.1/safeboot-wemos_d1_uno32.bin
 lib_deps =
   ${env.lib_deps}
   ${oss.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,8 @@
 
 [platformio]
 name = YaSolR
-default_envs = pro-esp32, pro-esp32s3, pro-lilygo_eth_lite_s3, pro-wt32_eth01
+;default_envs = pro-esp32, pro-esp32s3, pro-lilygo_eth_lite_s3, pro-wt32_eth01
+default_envs = oss-ESP32_D1_APPER
 
 [env]
 build_type = release
@@ -992,3 +993,47 @@ build_unflags =
 
 ; Hybrid compilation
 ;  Example: https://github.com/pioarduino/platform-espressif32/blob/main/examples/tasmota_platformio_override.ini
+
+
+
+;============ PKO ================================
+[ESP32_D1_APPER]
+build_flags =
+  -D YASOLR_I2C_SCL_PIN=-1
+  -D YASOLR_I2C_SDA_PIN=-1
+  -D YASOLR_JSY_RX_PIN=-1
+  -D YASOLR_JSY_SERIAL=Serial2
+  -D YASOLR_JSY_TX_PIN=-1
+  -D YASOLR_LIGHTS_GREEN_PIN=-1
+  -D YASOLR_LIGHTS_RED_PIN=-1
+  -D YASOLR_LIGHTS_YELLOW_PIN=-1
+  -D YASOLR_OUTPUT1_DIMMER_PIN=18
+  -D YASOLR_OUTPUT1_RELAY_PIN=17
+  -D YASOLR_OUTPUT1_TEMP_PIN=-1
+  -D YASOLR_OUTPUT2_DIMMER_PIN=22
+  -D YASOLR_OUTPUT2_RELAY_PIN=-1
+  -D YASOLR_OUTPUT2_TEMP_PIN=-1
+  -D YASOLR_PZEM_RX_PIN=-1
+  -D YASOLR_PZEM_SERIAL=Serial1
+  -D YASOLR_PZEM_TX_PIN=-1
+  -D YASOLR_RELAY1_PIN=21
+  -D YASOLR_RELAY2_PIN=5
+  -D YASOLR_SYSTEM_TEMP_PIN=23 ;//OneWire Dallas PIN DS18B20 (GPIO23)
+  -D YASOLR_ZCD_PIN=19
+
+
+
+[env:oss-ESP32_D1_APPER]
+board = wemos_d1_uno32
+custom_safeboot_url = https://github.com/mathieucarbou/MycilaSafeBoot/releases/download/v1.0.6/safeboot-esp32dev.bin
+lib_deps =
+  ${env.lib_deps}
+  ${oss.lib_deps}
+lib_ignore =
+  ${env.lib_ignore}
+  ${oss.lib_ignore}
+upload_speed = 921600
+build_flags =
+  ${env.build_flags}
+  ${oss.build_flags}
+  ${ESP32_D1_APPER.build_flags}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@ void setup() {
   yasolr_init_router();
   yasolr_init_trial();
   yasolr_init_web_server();
+  yasolr_init_modbus();
 
   // core task manager
   assert(coreTaskManager.asyncStart(512 * 8, 5, 1, 100, true));

--- a/src/yasolr_config.cpp
+++ b/src/yasolr_config.cpp
@@ -124,6 +124,11 @@ void yasolr_init_config() {
   config.configure(KEY_WIFI_PASSWORD);
   config.configure(KEY_WIFI_SSID);
 
+  // Modbus Configuration
+  config.configure(KEY_ENABLE_MODBUS, YASOLR_TRUE);
+  config.configure(KEY_MODBUS_SERVER, "192.168.1.16");
+  config.configure(KEY_MODBUS_PORT, "502");
+
   config.listen([]() {
     logger.info(TAG, "Configuration restored!");
     restartTask.resume();

--- a/src/yasolr_config.cpp
+++ b/src/yasolr_config.cpp
@@ -18,7 +18,7 @@ void yasolr_init_config() {
   config.configure(KEY_DISPLAY_SPEED, "3");
   config.configure(KEY_DISPLAY_TYPE, "SH1106");
   config.configure(KEY_ENABLE_AP_MODE, YASOLR_FALSE);
-  config.configure(KEY_ENABLE_DEBUG, YASOLR_FALSE);
+  config.configure(KEY_ENABLE_DEBUG, YASOLR_TRUE);
   config.configure(KEY_ENABLE_DISPLAY, YASOLR_FALSE);
   config.configure(KEY_ENABLE_DS18_SYSTEM, YASOLR_FALSE);
   config.configure(KEY_ENABLE_HA_DISCOVERY, YASOLR_FALSE);
@@ -40,7 +40,7 @@ void yasolr_init_config() {
   config.configure(KEY_ENABLE_OUTPUT2_RELAY, YASOLR_FALSE);
   config.configure(KEY_ENABLE_RELAY1, YASOLR_FALSE);
   config.configure(KEY_ENABLE_RELAY2, YASOLR_FALSE);
-  config.configure(KEY_ENABLE_ZCD, YASOLR_FALSE);
+  config.configure(KEY_ENABLE_ZCD, YASOLR_TRUE);
   config.configure(KEY_GRID_FREQUENCY, "0");
   config.configure(KEY_GRID_POWER_MQTT_TOPIC);
   config.configure(KEY_GRID_VOLTAGE_MQTT_TOPIC);
@@ -125,9 +125,9 @@ void yasolr_init_config() {
   config.configure(KEY_WIFI_SSID);
 
   // Modbus Configuration
-  config.configure(KEY_ENABLE_MODBUS, YASOLR_TRUE);
-  config.configure(KEY_MODBUS_SERVER, "192.168.1.16");
-  config.configure(KEY_MODBUS_PORT, "502");
+  config.configure(KEY_ENABLE_VICTRON_MB, YASOLR_FALSE);
+  config.configure(KEY_VICTRON_MB_SERVER);
+  config.configure(KEY_VICTRON_MB_PORT);
 
   config.listen([]() {
     logger.info(TAG, "Configuration restored!");

--- a/src/yasolr_config.cpp
+++ b/src/yasolr_config.cpp
@@ -18,7 +18,7 @@ void yasolr_init_config() {
   config.configure(KEY_DISPLAY_SPEED, "3");
   config.configure(KEY_DISPLAY_TYPE, "SH1106");
   config.configure(KEY_ENABLE_AP_MODE, YASOLR_FALSE);
-  config.configure(KEY_ENABLE_DEBUG, YASOLR_TRUE);
+  config.configure(KEY_ENABLE_DEBUG, YASOLR_FALSE);
   config.configure(KEY_ENABLE_DISPLAY, YASOLR_FALSE);
   config.configure(KEY_ENABLE_DS18_SYSTEM, YASOLR_FALSE);
   config.configure(KEY_ENABLE_HA_DISCOVERY, YASOLR_FALSE);
@@ -40,7 +40,7 @@ void yasolr_init_config() {
   config.configure(KEY_ENABLE_OUTPUT2_RELAY, YASOLR_FALSE);
   config.configure(KEY_ENABLE_RELAY1, YASOLR_FALSE);
   config.configure(KEY_ENABLE_RELAY2, YASOLR_FALSE);
-  config.configure(KEY_ENABLE_ZCD, YASOLR_TRUE);
+  config.configure(KEY_ENABLE_ZCD, YASOLR_FALSE);
   config.configure(KEY_GRID_FREQUENCY, "0");
   config.configure(KEY_GRID_POWER_MQTT_TOPIC);
   config.configure(KEY_GRID_VOLTAGE_MQTT_TOPIC);

--- a/src/yasolr_grid.cpp
+++ b/src/yasolr_grid.cpp
@@ -24,6 +24,13 @@ float yasolr_frequency() {
       return frequency;
   }
 
+  
+  // 4. frequency from modbbus
+  if (MB) { 
+    return modbus_frequency;
+  }
+
+
   return 0;
 }
 

--- a/src/yasolr_grid.cpp
+++ b/src/yasolr_grid.cpp
@@ -27,7 +27,9 @@ float yasolr_frequency() {
   
   // 4. frequency from modbbus
   if (MB) { 
-    return modbus_frequency;
+    frequency = modbus_frequency;
+    if (frequency>0)
+      return frequency;
   }
 
 

--- a/src/yasolr_modbus.cpp
+++ b/src/yasolr_modbus.cpp
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2023-2024 Mathieu Carbou
+ */
+#include <yasolr.h>
+
+
+
+static Mycila::Task* modbusTask = nullptr;
+
+static WiFiClient theClient;     
+
+float modbus_frequency = 0.0f;
+
+
+// Create a ModbusTCP client instance
+ModbusClientTCP* MB = nullptr;
+
+// Define a function to parse a signed 16-bit integer from a Modbus message response
+// (Modbus uses big-endian byte order)    
+// The response is a Modbus message, which is a vector of bytes
+// The function returns a signed 16-bit integer
+// scale : 10.0f for x10scale, 1.0f for no scale, 0.1f for 1 decimal, 0.01f for 2 decimals
+// signedValue : true if the value is signed, false if the value is unsigned 
+int16_t parseSignedorUnsignedInt16(ModbusMessage response,int offset,float scale,bool signedValue) {
+
+  int32_t value = 0;
+  // Combine the two bytes of the response into a signed 16-bit integer
+  // (Modbus uses big-endian byte order, so we have to swap the bytes)
+  //  - response[3] is the high byte
+  //  - response[4] is the low byte
+  *((unsigned char *)&value + 1) = response[offset];
+  *((unsigned char *)&value + 0) = response[offset+1];
+  
+  // Convert the 16-bit integer to a signed value
+  // (Modbus uses two's complement for negative values)
+  if (signedValue) {
+    if (value>=32768) {
+      value = value - 65536;
+    }
+  } 
+
+  // Apply the scaling factor
+  value = value * scale;
+  return value;
+}
+
+
+
+void parseVictronAC(ModbusMessage response){
+  // ======================== AC Input based on CCGX-Modbus-TCP-register-list-3.40 ==========================
+  // | SLAVE_ID | Description           | Register | Type   | Offset | Scale | Range               | Unit   |
+  // |----------|-----------------------|----------|--------|--------|-------|---------------------|--------|
+  // | 228      | Input voltage phase 1 | 3        | uint16 | 3 (*)  | 0.1f  | 0 to 6553.5         | V      |
+  // | 228      | Input voltage phase 2 | 4        | uint16 | 5      | 0.1f  | 0 to 6553.5         | V      |
+  // | 228      | Input voltage phase 3 | 5        | uint16 | 7      | 0.1f  | 0 to 6553.5         | V      |
+  // | 228      | Input current phase 1 | 6        | int16  | 9 (*)  | 0.1f  | -3276.8 to 3276.7   | A AC   |
+  // | 228      | Input current phase 2 | 7        | int16  | 11     | 0.1f  | -3276.8 to 3276.7   | A AC   |
+  // | 228      | Input current phase 3 | 8        | int16  | 13     | 0.1f  | -3276.8 to 3276.7   | A AC   |
+  // | 228      | Input frequency 1     | 9        | int16  | 15 (*) | 0.01f | -327.68 to 327.67   | Hz     |
+  // | 228      | Input frequency 2     | 10       | int16  | 17     | 0.01f | -327.68 to 327.67   | Hz     |
+  // | 228      | Input frequency 3     | 11       | int16  | 19     | 0.01f | -327.68 to 327.67   | Hz     |
+  // | 228      | Input power 1         | 12       | int16  | 21 (*) | 1f    | -32768.0 to 32767.0 | VA or W |
+  // | 228      | Input power 2         | 13       | int16  | 23     | 1f    | -32768.0 to 32767.0 | VA or W |
+  // | 228      | Input power 3         | 14       | int16  | 25     | 1f    | -32768.0 to 32767.0 | VA or W |
+  // =========================================================================================================
+
+  // Parse the response to get the input power
+  float voltage1 = parseSignedorUnsignedInt16(response,3,0.1f,false);
+  float current1 = parseSignedorUnsignedInt16(response,9,0.1f,true);
+  modbus_frequency = parseSignedorUnsignedInt16(response,15,0.01f,true);
+  float power1 = parseSignedorUnsignedInt16(response,21,1.0f,true);
+
+  if (config.getBool(KEY_ENABLE_DEBUG)) {
+    logger.info(TAG,"Victron AC input : %f V, %f A, %f Hz, %f W ", voltage1, current1, modbus_frequency, power1);
+  } 
+  
+
+  grid.remoteMetrics().update({
+    .apparentPower = power1,
+    .current =  current1,
+    .energy = static_cast<uint32_t>(0),
+    .energyReturned = static_cast<uint32_t>(0),
+    .power = power1 ,
+    .powerFactor =  NAN,
+    .voltage = voltage1 ,
+
+  });
+
+  if (grid.updatePower()) {
+    yasolr_divert();
+  }
+
+
+}
+
+// Define an onData handler function to receive the regular responses
+// Arguments are Modbus server ID, the function code requested, the message data and length of it, 
+// plus a user-supplied token to identify the causing request
+void handleData(ModbusMessage response, uint32_t token) 
+{
+  if (config.getBool(KEY_ENABLE_DEBUG)) {
+    logger.info(TAG,"Response: serverID=%d, FC=%d, Token=%08X, length=%d ", response.getServerID(), response.getFunctionCode(), token, response.size());
+    for (auto& byte : response) {
+      logger.info(TAG,"%02X ", byte);
+    }
+    logger.info(TAG,"=====================");
+   }
+  
+   parseVictronAC(response);
+
+
+
+ 
+
+}
+
+// Define an onError handler function to receive error responses
+// Arguments are the error code returned and a user-supplied token to identify the causing request
+void handleError(Error error, uint32_t token) 
+{
+  // ModbusError wraps the error code and provides a readable error message for it
+  ModbusError me(error);
+  logger.error(TAG,"Error response: %02X - %s token: %d", (int)me, (const char *)me, token);
+}
+
+
+// Initialize Modbus  TCP Client      
+//   - create a ModbusTCP client instance
+//   - set up the onData and onError handler functions  
+void yasolr_init_modbus() {
+
+  if (config.getBool(KEY_ENABLE_MODBUS)) {
+    assert(!MB);
+    assert(!modbusTask);
+
+    const char* modbus_IP = config.getString(KEY_MODBUS_SERVER).c_str();
+    const int modbus_port = config.getLong(KEY_MODBUS_PORT);
+
+    logger.info(TAG, "Initialize ModBus Client TCP Async on %s:%i", modbus_IP,modbus_port);
+
+    MB = new ModbusClientTCP(theClient,IPAddress(modbus_IP), modbus_port );
+
+    // Set up ModbusTCP client.
+    // - provide onData handler function
+    MB->onDataHandler(&handleData);
+    // - provide onError handler function
+    MB->onErrorHandler(&handleError);
+    // Set message timeout to 2000ms and interval between requests to the same host to 200ms
+    MB->setTimeout(2000,200);
+    // Start ModbusTCP background task
+    MB->begin();
+
+    modbusTask = new Mycila::Task("MODBUS", [](void* params) {
+        // Create request for
+        // - server ID = 228 
+        // - function code = 0x03 (read holding register)
+        // - start address to read = word 3 
+        // - number of words to read = 2 (1 word = 2 bytes, therefore int16_t = 1 word)  
+        // we read more than one register in one batch to save time, the VICTRON inverter has a lot of data to read
+        // - REG : 3 Input voltage phase 1
+        // - REG : 4 Input voltage phase 2
+        // - REG : 5 Input voltage phase 3  
+        // - REG : 6 Input current phase 1
+        // - REG : 7 Input current phase 2  
+        // - REG : 8 Input current phase 3
+        // - REG : 9 Input frequency phase 1
+        // - REG : 10 Input frequency phase 2
+        // - REG : 11 Input frequency phase 3
+        // - REG : 12 Input power power phase 1
+        // - REG : 13 Input power power phase 2 
+        // - REG : 14 Input power power phase 3
+        
+        // The request will be issued in the background task, with 12 words to read in a raw
+        // - token to match the response with the request. We take the current millis() value for it.
+        //
+        // If something is missing or wrong with the call parameters, we will immediately get an error code 
+        // and the request will not be issued
+        unsigned long lastMillis = millis();
+        Error err;
+        err = MB->addRequest((uint32_t)lastMillis,228, READ_HOLD_REGISTER, 3 , 12);
+        if (err != SUCCESS) {
+            ModbusError e(err);
+            logger.error(TAG,"Error creating request: %02X - %s\n", (int)e, (const char *)e);
+        }
+        // Else the request is processed in the background task and the onData/onError handler functions will get the result.
+      });
+
+    modbusTask->setInterval(500);
+    if (config.getBool(KEY_ENABLE_DEBUG))
+        modbusTask->enableProfiling();
+
+    unsafeTaskManager.addTask(*modbusTask);
+
+
+    }
+
+}
+
+
+


### PR DESCRIPTION
Proposition d'ajouter la lecture des informations Grid via ModBusTCP. Exemple d'implémentation pour un onduleur Victron.

Il est nécessaire de récupérer la librairie eModBus, en modifiant la version AsyncTCP pour utiliser celle du projet. J'ai pas réussi à la proposer dans la PR. J'avais juste modifié le fichier library.json

Preneur de revue de code, car je ne maitrise pas forcément toutes les notions utilisées. 

