### PR TITLE
Change grid_frequency HA type to gauge

### DIFF
--- a/src/yasolr_mqtt.cpp
+++ b/src/yasolr_mqtt.cpp
@@ -440,7 +440,7 @@ static void haDiscovery() {
   haDiscovery.publish(Mycila::HA::State("grid", "Grid Electricity", "/grid/online", YASOLR_TRUE, YASOLR_FALSE, "power"));
   haDiscovery.publish(Mycila::HA::Counter("grid_energy", "Grid Energy", "/grid/energy", "energy", nullptr, "Wh"));
   haDiscovery.publish(Mycila::HA::Counter("grid_energy_returned", "Grid Energy Returned", "/grid/energy_returned", "energy", nullptr, "Wh"));
-  haDiscovery.publish(Mycila::HA::Counter("grid_frequency", "Grid Frequency", "/grid/frequency", "frequency", nullptr, "Hz"));
+  haDiscovery.publish(Mycila::HA::Gauge("grid_frequency", "Grid Frequency", "/grid/frequency", "frequency", nullptr, "Hz"));
   haDiscovery.publish(Mycila::HA::Gauge("grid_power", "Grid Power", "/grid/power", "power", nullptr, "W"));
   haDiscovery.publish(Mycila::HA::Gauge("grid_power_virtual", "Grid Power Without Routing", "/router/virtual_grid_power", "power", nullptr, "W"));
   haDiscovery.publish(Mycila::HA::Gauge("grid_power_factor", "Grid Power Factor", "/grid/power_factor", "power_factor"));


### PR DESCRIPTION
The grid frequency should not be a counter, it's not an always increasing value. This will get rid of warnings in HA such as:

```
WARNING (Recorder) [homeassistant.components.sensor.recorder] Entity sensor.yasolr_ca341c_grid_frequency from integration mqtt has state class total_increasing, but its state is not strictly increasing. Triggered by state 49.959999 (49.969997) with last_updated set to 2025-04-21T10:30:08.885195+00:00. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22
```